### PR TITLE
Fix service worker cache response type bug

### DIFF
--- a/sw.js
+++ b/sw.js
@@ -34,18 +34,22 @@ self.addEventListener('fetch', event => {
         
         return fetch(fetchRequest).then(response => {
           // Check if valid response
-          if (!response || response.status !== 200 || response.type !== 'basic') {
+          // Allow both 'basic' (same-origin) and 'cors' (cross-origin with CORS) responses
+          if (!response || response.status !== 200 || (response.type !== 'basic' && response.type !== 'cors')) {
             return response;
           }
-          
+
           // Clone the response
           const responseToCache = response.clone();
-          
+
           caches.open(CACHE_NAME)
             .then(cache => {
               cache.put(event.request, responseToCache);
+            })
+            .catch(err => {
+              console.error('Failed to cache:', err);
             });
-          
+
           return response;
         });
       })


### PR DESCRIPTION
The service worker was only caching 'basic' type responses, which excluded cross-origin resources. This prevented caching of CDN resources, external scripts, and other CORS-enabled resources.

Changes:
- Allow both 'basic' and 'cors' response types to be cached
- Add error handler for cache.put operation
- Add clarifying comment about response types

This fix ensures that cross-origin resources with proper CORS headers can now be cached by the service worker, improving offline functionality.